### PR TITLE
Supervisord config file was not being created

### DIFF
--- a/provisioning/run-vars.yml
+++ b/provisioning/run-vars.yml
@@ -5,6 +5,7 @@ flow_manager_preferences_server_host_address: "{{ lookup('env', 'PREFERENCES_SER
 flow_manager_environment: "{{ lookup('env', 'NODE_ENV') | default('cloudBased.production',true) }}"
 
 # Although this has been already specified in the GPII/universal, it's needed here for the deploy phase again.
+nodejs_app_name: universal
 nodejs_app_start_script: gpii.js
 
 # self-test configuration for CONTAINER_TEST mode

--- a/provisioning/run-vars.yml
+++ b/provisioning/run-vars.yml
@@ -4,6 +4,9 @@
 flow_manager_preferences_server_host_address: "{{ lookup('env', 'PREFERENCES_SERVER_HOST_ADDRESS') | default('localhost:8082',true) }}"
 flow_manager_environment: "{{ lookup('env', 'NODE_ENV') | default('cloudBased.production',true) }}"
 
+# Although this has been already specified in the GPII/universal, it's needed here for the deploy phase again.
+nodejs_app_start_script: gpii.js
+
 # self-test configuration for CONTAINER_TEST mode
 nodejs_app_host_address: 127.0.0.1
 nodejs_app_tcp_port: 8081


### PR DESCRIPTION
The coupling between the universal and flow-manager images is very high. That means whatever app name was defined in the universal image (where the git repository gets cloned), must again be passed on to Ansible when the flow-manager image runs.

This PR makes the app_name and app_start_script variables available so the 'deploy' phase of the nodejs role can run when starting the flow-manager image and create the necessary supervisord config file.
